### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ All `document.tex` files use a configuration block similar to:
 
 ## CI/CD Pipeline
 
-There is no CI/CD pipeline configured in this repository. All validation is performed locally before submitting a pull request.
+A `release.yaml` workflow runs on push to `main` and delegates to a shared pipeline (`rios0rios0/pipelines`) to create GitHub releases. There is no build or test CI — all validation is performed locally before submitting a pull request.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the new `release.yaml` CI workflow
+
 ## [1.1.0] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.